### PR TITLE
[ROS2] Port kindr_ros and kindr_msgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,24 +20,29 @@ ROS messages and RViz plugins for kindr objects.
 
 ## Packages
 
-### kindr_msgs
+### kindr_msgs (supports ROS2)
 
 ROS messages for kindr objects.
 
-### kindr_ros
+### kindr_ros (supports ROS2)
 
 Conversion between official ROS messages and kindr objects.
 
-### kindr_rviz_plugins
+### kindr_rviz_plugins (Not yet ported)
 
 RViz plugins to visualize kindr ROS messages.
 
-### multi_dof_joint_trajectory_rviz_plugins
+### multi_dof_joint_trajectory_rviz_plugins (Not yet ported)
 
 RViz plugins to visualize trajectory ROS messages.
 
 ## Usage
 
-To build, clone this repository into your catkin workspace and type
+To build, clone this repository into your colcon workspace and type
 
-    catkin build <package_name>
+    colcon build --packages-up-to <package_name>
+
+To run tests type:
+
+    colcon test --packages-select <package_name>
+    colcon test-result --all --verbose

--- a/kindr_msgs/CMakeLists.txt
+++ b/kindr_msgs/CMakeLists.txt
@@ -45,8 +45,8 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## Generate messages in the 'msg' folder
 add_message_files(
-   FILES
-   VectorAtPosition.msg
+  FILES
+  VectorAtPosition.msg
 )
 
 ## Generate services in the 'srv' folder
@@ -68,7 +68,7 @@ generate_messages(
   DEPENDENCIES
   geometry_msgs
   std_msgs
- )
+)
 
 ###################################
 ## catkin specific configuration ##

--- a/kindr_msgs/CMakeLists.txt
+++ b/kindr_msgs/CMakeLists.txt
@@ -1,163 +1,17 @@
 cmake_minimum_required(VERSION 3.5.1)
 project(kindr_msgs)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  message_generation
-  geometry_msgs
-  std_msgs
+find_package(ament_cmake_auto)
+ament_auto_find_build_dependencies()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/VectorAtPosition.msg"
+  ADD_LINTER_TESTS
 )
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
 
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-add_message_files(
-  FILES
-  VectorAtPosition.msg
-)
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES
-  geometry_msgs
-  std_msgs
-)
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES kindr_msgs
-  CATKIN_DEPENDS message_runtime geometry_msgs std_msgs
-#  DEPENDS system_lib
-)
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
-include_directories(
-  ${catkin_INCLUDE_DIRS}
-)
-
-## Declare a cpp library
-# add_library(kindr_msgs
-#   src/${PROJECT_NAME}/kindr_msgs.cpp
-# )
-
-## Declare a cpp executable
-# add_executable(kindr_msgs_node src/kindr_msgs_node.cpp)
-
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(kindr_msgs_node kindr_msgs_generate_messages_cpp)
-
-## Specify libraries to link a library or executable target against
-# target_link_libraries(kindr_msgs_node
-#   ${catkin_LIBRARIES}
-# )
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables and/or libraries for installation
-# install(TARGETS kindr_msgs kindr_msgs_node
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_kindr_msgs.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+ament_auto_package()

--- a/kindr_msgs/msg/VectorAtPosition.msg
+++ b/kindr_msgs/msg/VectorAtPosition.msg
@@ -12,7 +12,7 @@ uint8 TYPE_ANGULAR_VELOCITY=14
 uint8 TYPE_TORQUE=16
 uint8 TYPE_ANGULAR_MOMEMTUM=17
 
-Header header
+std_msgs/Header header
 uint8 type
 string name
 geometry_msgs/Vector3 vector # Frame defined in header

--- a/kindr_msgs/package.xml
+++ b/kindr_msgs/package.xml
@@ -12,13 +12,21 @@
 
   <author email="pfankhauser@anybotics.com">Peter Fankhauser</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
-  <build_depend>message_generation</build_depend>
+  <build_depend>rosidl_default_generators</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/kindr_msgs/package.xml
+++ b/kindr_msgs/package.xml
@@ -1,21 +1,24 @@
 <?xml version="1.0"?>
-<package>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>kindr_msgs</name>
   <version>0.3.4</version>
   <description>Kindr common msgs</description>
   <maintainer email="rdiethelm@anybotics.com">Remo Diethelm</maintainer>
   <maintainer email="pleemann@anybotics.com">Philipp Leemann</maintainer>
-  <author email="pfankhauser@anybotics.com">Peter Fankhauser</author>
+
   <license>BSD</license>
-  <url>https://github.com/anybotics/kindr_ros</url>
+  <url type="website">https://github.com/anybotics/kindr_ros</url>
+
+  <author email="pfankhauser@anybotics.com">Peter Fankhauser</author>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>message_generation</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>std_msgs</build_depend>
 
-  <run_depend>message_runtime</run_depend>
-  <run_depend>geometry_msgs</run_depend>
-  <run_depend>std_msgs</run_depend>
-
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
 </package>

--- a/kindr_ros/CMakeLists.txt
+++ b/kindr_ros/CMakeLists.txt
@@ -4,8 +4,9 @@ project(kindr_ros)
 add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
-  geometry_msgs tf
-  )
+  geometry_msgs
+  tf
+)
 
 # Attempt to find catkinized kindr
 find_package(kindr QUIET)
@@ -42,16 +43,16 @@ if(CATKIN_ENABLE_TESTING)
     test/RosTfPoseTest.cpp
     test/TfConventionTest.cpp
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
-    )
+  )
   if(TARGET ${PROJECT_NAME}-test)
     target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES})
     find_package(cmake_code_coverage QUIET)
     if(cmake_code_coverage_FOUND)
       add_gtest_coverage(TEST_BUILD_TARGETS ${PROJECT_NAME}-test)
-    endif(cmake_code_coverage_FOUND)
+    endif()
   endif()
 endif()
 
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-  )
+)

--- a/kindr_ros/CMakeLists.txt
+++ b/kindr_ros/CMakeLists.txt
@@ -5,7 +5,7 @@ add_definitions(-std=c++11)
 
 find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
-  tf
+  tf2
 )
 
 # Attempt to find catkinized kindr
@@ -21,7 +21,7 @@ find_package(Eigen3 REQUIRED)
 catkin_package(
   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
   #  LIBRARIES kindr_ros
-  CATKIN_DEPENDS geometry_msgs tf
+  CATKIN_DEPENDS geometry_msgs tf2
   DEPENDS kindr
 )
 

--- a/kindr_ros/CMakeLists.txt
+++ b/kindr_ros/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.5)
 project(kindr_ros)
 
 # Use C++14 standard
@@ -13,30 +13,19 @@ find_package(ament_cmake REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(geometry_msgs REQUIRED)
 find_package(kindr REQUIRED)
+
+find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-include_directories(include)
-include_directories(${EIGEN3_INCLUDE_DIR})
-include_directories(${kindr_INCLUDE_DIRS})
-
-add_library(${PROJECT_NAME} INTERFACE)
-
-set_target_properties(${PROJECT_NAME} PROPERTIES
-  PUBLIC_HEADER
-  kindr_ros/kindr_ros.hpp
-  kindr_ros/RosGeometryMsgPhysicalQuantities.hpp
-  kindr_ros/RosGeometryMsgPose.hpp
-  kindr_ros/RosGeometryMsgRotation.hpp
-  kindr_ros/RosGeometryMsgTwist.hpp
-  kindr_ros/RosTfPose.hpp
+set(dependencies
+  eigen3_cmake_module
+  Eigen3
+  tf2
+  geometry_msgs
 )
 
-install(
-  TARGETS
-    ${PROJECT_NAME}
-  PUBLIC_HEADER
-    DESTINATION include
-)
+install(DIRECTORY include/${PROJECT_NAME}/
+        DESTINATION include/${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
@@ -55,20 +44,25 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
   )
 
-  # TODO(SivertHavso): add back code coverage:
-  # if(TARGET ${PROJECT_NAME}-test)
-  #   target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES})
-  #   find_package(cmake_code_coverage QUIET)
-  #   if(cmake_code_coverage_FOUND)
-  #     add_gtest_coverage(TEST_BUILD_TARGETS ${PROJECT_NAME}-test)
-  #   endif()
-  # endif()
+  if(TARGET ${PROJECT_NAME}-test)
+    target_include_directories(${PROJECT_NAME}-test PUBLIC
+      include
+      ${EIGEN3_INCLUDE_DIRS})
+    ament_target_dependencies(${PROJECT_NAME}-test
+      ${dependencies}
+    )
+    # TODO(SivertHavso): add back code coverage:
+    #   find_package(cmake_code_coverage QUIET)
+    #   if(cmake_code_coverage_FOUND)
+    #     add_gtest_coverage(TEST_BUILD_TARGETS ${PROJECT_NAME}-test)
+    #   endif()
+  endif()
 endif()
 
-ament_export_include_directories(include ${EIGEN3_INCLUDE_DIR})
+ament_export_include_directories(include)
 
-ament_export_libraries(
-  ${PROJECT_NAME}
+ament_export_dependencies(
+  ${dependencies}
 )
 
 ament_package()

--- a/kindr_ros/CMakeLists.txt
+++ b/kindr_ros/CMakeLists.txt
@@ -1,41 +1,51 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.15)
 project(kindr_ros)
 
-add_definitions(-std=c++11)
-
-find_package(catkin REQUIRED COMPONENTS
-  geometry_msgs
-  tf2
-)
-
-# Attempt to find catkinized kindr
-find_package(kindr QUIET)
-if(NOT kindr_FOUND)
-  # Attempt to find package-based kindr
-  find_package(PkgConfig REQUIRED)
-  pkg_check_modules(kindr kindr REQUIRED)
+# Use C++14 standard
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
+find_package(ament_cmake REQUIRED)
+find_package(tf2 REQUIRED)
+find_package(geometry_msgs REQUIRED)
+find_package(kindr REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-catkin_package(
-  INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
-  #  LIBRARIES kindr_ros
-  CATKIN_DEPENDS geometry_msgs tf2
-  DEPENDS kindr
-)
-
 include_directories(include)
-include_directories(${catkin_INCLUDE_DIRS})
 include_directories(${EIGEN3_INCLUDE_DIR})
 include_directories(${kindr_INCLUDE_DIRS})
 
-#############
-## Testing ##
-#############
+add_library(${PROJECT_NAME} INTERFACE)
 
-if(CATKIN_ENABLE_TESTING)
-  catkin_add_gtest(${PROJECT_NAME}-test
+set_target_properties(${PROJECT_NAME} PROPERTIES
+  PUBLIC_HEADER
+  kindr_ros/kindr_ros.hpp
+  kindr_ros/RosGeometryMsgPhysicalQuantities.hpp
+  kindr_ros/RosGeometryMsgPose.hpp
+  kindr_ros/RosGeometryMsgRotation.hpp
+  kindr_ros/RosGeometryMsgTwist.hpp
+  kindr_ros/RosTfPose.hpp
+)
+
+install(
+  TARGETS
+    ${PROJECT_NAME}
+  PUBLIC_HEADER
+    DESTINATION include
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(${PROJECT_NAME}-test
     test/test_main.cpp
     test/RosGeometryMsgPhysicalQuantitiesTest.cpp
     test/RosGeometryMsgRotationTest.cpp
@@ -44,15 +54,21 @@ if(CATKIN_ENABLE_TESTING)
     test/TfConventionTest.cpp
     WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/test
   )
-  if(TARGET ${PROJECT_NAME}-test)
-    target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES})
-    find_package(cmake_code_coverage QUIET)
-    if(cmake_code_coverage_FOUND)
-      add_gtest_coverage(TEST_BUILD_TARGETS ${PROJECT_NAME}-test)
-    endif()
-  endif()
+
+  # TODO(SivertHavso): add back code coverage:
+  # if(TARGET ${PROJECT_NAME}-test)
+  #   target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES})
+  #   find_package(cmake_code_coverage QUIET)
+  #   if(cmake_code_coverage_FOUND)
+  #     add_gtest_coverage(TEST_BUILD_TARGETS ${PROJECT_NAME}-test)
+  #   endif()
+  # endif()
 endif()
 
-install(DIRECTORY include/${PROJECT_NAME}/
-  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+ament_export_include_directories(include ${EIGEN3_INCLUDE_DIR})
+
+ament_export_libraries(
+  ${PROJECT_NAME}
 )
+
+ament_package()

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgPhysicalQuantities.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgPhysicalQuantities.hpp
@@ -34,9 +34,9 @@
 #include <kindr/Core>
 
 // ros
-#include <geometry_msgs/Vector3.h>
-#include <geometry_msgs/Point.h>
-#include <geometry_msgs/Point32.h>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/point32.hpp>
 
 
 namespace kindr_ros
@@ -45,7 +45,7 @@ namespace kindr_ros
 
 template<enum kindr::PhysicalType PhysicalType_, typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-  const geometry_msgs::Vector3 & geometryVector3Msg,
+  const geometry_msgs::msg::Vector3 & geometryVector3Msg,
   kindr::Vector<PhysicalType_, PrimType_, 3> & vector)
 {
   vector.x() = static_cast<PrimType_>(geometryVector3Msg.x);
@@ -56,7 +56,7 @@ inline static void convertFromRosGeometryMsg(
 template<enum kindr::PhysicalType PhysicalType_, typename PrimType_>
 inline static void convertToRosGeometryMsg(
   const kindr::Vector<PhysicalType_, PrimType_, 3> & vector,
-  geometry_msgs::Vector3 & geometryVector3Msg)
+  geometry_msgs::msg::Vector3 & geometryVector3Msg)
 {
   geometryVector3Msg.x = static_cast<double>(vector.x());
   geometryVector3Msg.y = static_cast<double>(vector.y());
@@ -65,7 +65,7 @@ inline static void convertToRosGeometryMsg(
 
 template<typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-  const geometry_msgs::Point32 & geometryPoint32Msg,
+  const geometry_msgs::msg::Point32 & geometryPoint32Msg,
   kindr::Position<PrimType_, 3> & position)
 {
   position.x() = static_cast<PrimType_>(geometryPoint32Msg.x);
@@ -76,7 +76,7 @@ inline static void convertFromRosGeometryMsg(
 template<typename PrimType_>
 inline static void convertToRosGeometryMsg(
   const kindr::Position<PrimType_, 3> & position,
-  geometry_msgs::Point32 & geometryPoint32Msg)
+  geometry_msgs::msg::Point32 & geometryPoint32Msg)
 {
   geometryPoint32Msg.x = static_cast<float>(position.x());
   geometryPoint32Msg.y = static_cast<float>(position.y());
@@ -85,7 +85,7 @@ inline static void convertToRosGeometryMsg(
 
 template<typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-  const geometry_msgs::Point & geometryPointMsg,
+  const geometry_msgs::msg::Point & geometryPointMsg,
   kindr::Position<PrimType_, 3> & position)
 {
   position.x() = static_cast<PrimType_>(geometryPointMsg.x);
@@ -96,7 +96,7 @@ inline static void convertFromRosGeometryMsg(
 template<typename PrimType_>
 inline static void convertToRosGeometryMsg(
   const kindr::Position<PrimType_, 3> & position,
-  geometry_msgs::Point & geometryPointMsg)
+  geometry_msgs::msg::Point & geometryPointMsg)
 {
   geometryPointMsg.x = static_cast<double>(position.x());
   geometryPointMsg.y = static_cast<double>(position.y());

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgPhysicalQuantities.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgPhysicalQuantities.hpp
@@ -26,7 +26,8 @@
  *
 */
 
-#pragma once
+#ifndef KINDR_ROS__ROSGEOMETRYMSGPHYSICALQUANTITIES_HPP_
+#define KINDR_ROS__ROSGEOMETRYMSGPHYSICALQUANTITIES_HPP_
 
 
 // kindr
@@ -38,13 +39,14 @@
 #include <geometry_msgs/Point32.h>
 
 
-namespace kindr_ros {
+namespace kindr_ros
+{
 
 
 template<enum kindr::PhysicalType PhysicalType_, typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-    const geometry_msgs::Vector3& geometryVector3Msg,
-    kindr::Vector<PhysicalType_, PrimType_, 3>& vector)
+  const geometry_msgs::Vector3 & geometryVector3Msg,
+  kindr::Vector<PhysicalType_, PrimType_, 3> & vector)
 {
   vector.x() = static_cast<PrimType_>(geometryVector3Msg.x);
   vector.y() = static_cast<PrimType_>(geometryVector3Msg.y);
@@ -53,48 +55,48 @@ inline static void convertFromRosGeometryMsg(
 
 template<enum kindr::PhysicalType PhysicalType_, typename PrimType_>
 inline static void convertToRosGeometryMsg(
-    const kindr::Vector<PhysicalType_, PrimType_, 3>& vector,
-    geometry_msgs::Vector3& geometryVector3Msg)
+  const kindr::Vector<PhysicalType_, PrimType_, 3> & vector,
+  geometry_msgs::Vector3 & geometryVector3Msg)
 {
   geometryVector3Msg.x = static_cast<double>(vector.x());
   geometryVector3Msg.y = static_cast<double>(vector.y());
   geometryVector3Msg.z = static_cast<double>(vector.z());
 }
 
-template <typename PrimType_>
+template<typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-    const geometry_msgs::Point32& geometryPoint32Msg,
-    kindr::Position<PrimType_, 3>& position)
+  const geometry_msgs::Point32 & geometryPoint32Msg,
+  kindr::Position<PrimType_, 3> & position)
 {
   position.x() = static_cast<PrimType_>(geometryPoint32Msg.x);
   position.y() = static_cast<PrimType_>(geometryPoint32Msg.y);
   position.z() = static_cast<PrimType_>(geometryPoint32Msg.z);
 }
 
-template <typename PrimType_>
+template<typename PrimType_>
 inline static void convertToRosGeometryMsg(
-    const kindr::Position<PrimType_, 3>& position,
-    geometry_msgs::Point32& geometryPoint32Msg)
+  const kindr::Position<PrimType_, 3> & position,
+  geometry_msgs::Point32 & geometryPoint32Msg)
 {
   geometryPoint32Msg.x = static_cast<float>(position.x());
   geometryPoint32Msg.y = static_cast<float>(position.y());
   geometryPoint32Msg.z = static_cast<float>(position.z());
 }
 
-template <typename PrimType_>
+template<typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-    const geometry_msgs::Point& geometryPointMsg,
-    kindr::Position<PrimType_, 3>& position)
+  const geometry_msgs::Point & geometryPointMsg,
+  kindr::Position<PrimType_, 3> & position)
 {
   position.x() = static_cast<PrimType_>(geometryPointMsg.x);
   position.y() = static_cast<PrimType_>(geometryPointMsg.y);
   position.z() = static_cast<PrimType_>(geometryPointMsg.z);
 }
 
-template <typename PrimType_>
+template<typename PrimType_>
 inline static void convertToRosGeometryMsg(
-    const kindr::Position<PrimType_, 3>& position,
-    geometry_msgs::Point& geometryPointMsg)
+  const kindr::Position<PrimType_, 3> & position,
+  geometry_msgs::Point & geometryPointMsg)
 {
   geometryPointMsg.x = static_cast<double>(position.x());
   geometryPointMsg.y = static_cast<double>(position.y());
@@ -102,4 +104,6 @@ inline static void convertToRosGeometryMsg(
 }
 
 
-} // namespace kindr_ros
+}  // namespace kindr_ros
+
+#endif  // KINDR_ROS__ROSGEOMETRYMSGPHYSICALQUANTITIES_HPP_

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgPose.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgPose.hpp
@@ -26,7 +26,8 @@
  *
 */
 
-#pragma once
+#ifndef KINDR_ROS__ROSGEOMETRYMSGPOSE_HPP_
+#define KINDR_ROS__ROSGEOMETRYMSGPOSE_HPP_
 
 
 // kindr
@@ -41,13 +42,14 @@
 #include "kindr_ros/RosGeometryMsgRotation.hpp"
 
 
-namespace kindr_ros {
+namespace kindr_ros
+{
 
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertFromRosGeometryMsg(
-    const geometry_msgs::Pose& geometryPoseMsg,
-    kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_>& pose)
+  const geometry_msgs::Pose & geometryPoseMsg,
+  kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & pose)
 {
   convertFromRosGeometryMsg(geometryPoseMsg.position, pose.getPosition());
 
@@ -61,8 +63,8 @@ inline static void convertFromRosGeometryMsg(
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertToRosGeometryMsg(
-    const kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_>& pose,
-    geometry_msgs::Pose& geometryPoseMsg)
+  const kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & pose,
+  geometry_msgs::Pose & geometryPoseMsg)
 {
   convertToRosGeometryMsg(pose.getPosition(), geometryPoseMsg.position);
 
@@ -75,8 +77,8 @@ inline static void convertToRosGeometryMsg(
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertFromRosGeometryMsg(
-    const geometry_msgs::Transform& geometryTransformMsg,
-    kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_>& transformation)
+  const geometry_msgs::Transform & geometryTransformMsg,
+  kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & transformation)
 {
   convertFromRosGeometryMsg(geometryTransformMsg.translation, transformation.getPosition());
 
@@ -90,8 +92,8 @@ inline static void convertFromRosGeometryMsg(
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertToRosGeometryMsg(
-    const kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_>& transformation,
-    geometry_msgs::Transform& geometryTransformMsg)
+  const kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & transformation,
+  geometry_msgs::Transform & geometryTransformMsg)
 {
   convertToRosGeometryMsg(transformation.getPosition(), geometryTransformMsg.translation);
 
@@ -103,4 +105,6 @@ inline static void convertToRosGeometryMsg(
 }
 
 
-} // namespace kindr_ros
+}  // namespace kindr_ros
+
+#endif  // KINDR_ROS__ROSGEOMETRYMSGPOSE_HPP_

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgPose.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgPose.hpp
@@ -34,8 +34,8 @@
 #include <kindr/Core>
 
 // ros
-#include <geometry_msgs/Pose.h>
-#include <geometry_msgs/Transform.h>
+#include <geometry_msgs/msg/pose.hpp>
+#include <geometry_msgs/msg/transform.hpp>
 
 // kindr ros
 #include "kindr_ros/RosGeometryMsgPhysicalQuantities.hpp"
@@ -48,7 +48,7 @@ namespace kindr_ros
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertFromRosGeometryMsg(
-  const geometry_msgs::Pose & geometryPoseMsg,
+  const geometry_msgs::msg::Pose & geometryPoseMsg,
   kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & pose)
 {
   convertFromRosGeometryMsg(geometryPoseMsg.position, pose.getPosition());
@@ -64,7 +64,7 @@ inline static void convertFromRosGeometryMsg(
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertToRosGeometryMsg(
   const kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & pose,
-  geometry_msgs::Pose & geometryPoseMsg)
+  geometry_msgs::msg::Pose & geometryPoseMsg)
 {
   convertToRosGeometryMsg(pose.getPosition(), geometryPoseMsg.position);
 
@@ -77,7 +77,7 @@ inline static void convertToRosGeometryMsg(
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertFromRosGeometryMsg(
-  const geometry_msgs::Transform & geometryTransformMsg,
+  const geometry_msgs::msg::Transform & geometryTransformMsg,
   kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & transformation)
 {
   convertFromRosGeometryMsg(geometryTransformMsg.translation, transformation.getPosition());
@@ -93,7 +93,7 @@ inline static void convertFromRosGeometryMsg(
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertToRosGeometryMsg(
   const kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_> & transformation,
-  geometry_msgs::Transform & geometryTransformMsg)
+  geometry_msgs::msg::Transform & geometryTransformMsg)
 {
   convertToRosGeometryMsg(transformation.getPosition(), geometryTransformMsg.translation);
 

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgRotation.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgRotation.hpp
@@ -26,7 +26,8 @@
  *
 */
 
-#pragma once
+#ifndef KINDR_ROS__ROSGEOMETRYMSGROTATION_HPP_
+#define KINDR_ROS__ROSGEOMETRYMSGROTATION_HPP_
 
 
 // kindr
@@ -36,24 +37,26 @@
 #include <geometry_msgs/Quaternion.h>
 
 
-namespace kindr_ros {
+namespace kindr_ros
+{
 
 
 template<typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-    const geometry_msgs::Quaternion& geometryQuaternionMsg,
-    kindr::RotationQuaternion<PrimType_>& rotationQuaternion)
+  const geometry_msgs::Quaternion & geometryQuaternionMsg,
+  kindr::RotationQuaternion<PrimType_> & rotationQuaternion)
 {
-  rotationQuaternion.setValues(static_cast<PrimType_>(geometryQuaternionMsg.w),
-                               static_cast<PrimType_>(geometryQuaternionMsg.x),
-                               static_cast<PrimType_>(geometryQuaternionMsg.y),
-                               static_cast<PrimType_>(geometryQuaternionMsg.z));
+  rotationQuaternion.setValues(
+    static_cast<PrimType_>(geometryQuaternionMsg.w),
+    static_cast<PrimType_>(geometryQuaternionMsg.x),
+    static_cast<PrimType_>(geometryQuaternionMsg.y),
+    static_cast<PrimType_>(geometryQuaternionMsg.z));
 }
 
 template<typename PrimType_>
 inline static void convertToRosGeometryMsg(
-    const kindr::RotationQuaternion<PrimType_>& rotationQuaternion,
-    geometry_msgs::Quaternion& geometryQuaternionMsg)
+  const kindr::RotationQuaternion<PrimType_> & rotationQuaternion,
+  geometry_msgs::Quaternion & geometryQuaternionMsg)
 {
   geometryQuaternionMsg.w = static_cast<double>(rotationQuaternion.w());
   geometryQuaternionMsg.x = static_cast<double>(rotationQuaternion.x());
@@ -61,4 +64,6 @@ inline static void convertToRosGeometryMsg(
   geometryQuaternionMsg.z = static_cast<double>(rotationQuaternion.z());
 }
 
-} // namespace kindr_ros
+}  // namespace kindr_ros
+
+#endif  // KINDR_ROS__ROSGEOMETRYMSGROTATION_HPP_

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgRotation.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgRotation.hpp
@@ -34,7 +34,7 @@
 #include <kindr/Core>
 
 // ros
-#include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/msg/quaternion.hpp>
 
 
 namespace kindr_ros
@@ -43,7 +43,7 @@ namespace kindr_ros
 
 template<typename PrimType_>
 inline static void convertFromRosGeometryMsg(
-  const geometry_msgs::Quaternion & geometryQuaternionMsg,
+  const geometry_msgs::msg::Quaternion & geometryQuaternionMsg,
   kindr::RotationQuaternion<PrimType_> & rotationQuaternion)
 {
   rotationQuaternion.setValues(
@@ -56,7 +56,7 @@ inline static void convertFromRosGeometryMsg(
 template<typename PrimType_>
 inline static void convertToRosGeometryMsg(
   const kindr::RotationQuaternion<PrimType_> & rotationQuaternion,
-  geometry_msgs::Quaternion & geometryQuaternionMsg)
+  geometry_msgs::msg::Quaternion & geometryQuaternionMsg)
 {
   geometryQuaternionMsg.w = static_cast<double>(rotationQuaternion.w());
   geometryQuaternionMsg.x = static_cast<double>(rotationQuaternion.x());

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgTwist.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgTwist.hpp
@@ -26,7 +26,8 @@
  *
 */
 
-#pragma once
+#ifndef KINDR_ROS__ROSGEOMETRYMSGTWIST_HPP_
+#define KINDR_ROS__ROSGEOMETRYMSGTWIST_HPP_
 
 
 // kindr
@@ -39,13 +40,14 @@
 #include "kindr_ros/RosGeometryMsgPhysicalQuantities.hpp"
 
 
-namespace kindr_ros {
+namespace kindr_ros
+{
 
 
 template<typename PrimType_, typename PositionDiff_, typename RotationDiff_>
 inline static void convertFromRosGeometryMsg(
-    const geometry_msgs::Twist& geometryTwistMsg,
-    kindr::Twist<PrimType_, PositionDiff_, RotationDiff_>& twist)
+  const geometry_msgs::Twist & geometryTwistMsg,
+  kindr::Twist<PrimType_, PositionDiff_, RotationDiff_> & twist)
 {
   convertFromRosGeometryMsg(geometryTwistMsg.linear, twist.getTranslationalVelocity());
   convertFromRosGeometryMsg(geometryTwistMsg.angular, twist.getRotationalVelocity());
@@ -53,12 +55,14 @@ inline static void convertFromRosGeometryMsg(
 
 template<typename PrimType_, typename PositionDiff_, typename RotationDiff_>
 inline static void convertToRosGeometryMsg(
-    const kindr::Twist<PrimType_, PositionDiff_, RotationDiff_>& twist,
-    geometry_msgs::Twist& geometryTwistMsg)
+  const kindr::Twist<PrimType_, PositionDiff_, RotationDiff_> & twist,
+  geometry_msgs::Twist & geometryTwistMsg)
 {
   convertToRosGeometryMsg(twist.getTranslationalVelocity(), geometryTwistMsg.linear);
   convertToRosGeometryMsg(twist.getRotationalVelocity(), geometryTwistMsg.angular);
 }
 
 
-} // namespace kindr_ros
+}  // namespace kindr_ros
+
+#endif  // KINDR_ROS__ROSGEOMETRYMSGTWIST_HPP_

--- a/kindr_ros/include/kindr_ros/RosGeometryMsgTwist.hpp
+++ b/kindr_ros/include/kindr_ros/RosGeometryMsgTwist.hpp
@@ -34,7 +34,7 @@
 #include <kindr/Core>
 
 // ros
-#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/msg/twist.hpp>
 
 // kindr ros
 #include "kindr_ros/RosGeometryMsgPhysicalQuantities.hpp"
@@ -46,7 +46,7 @@ namespace kindr_ros
 
 template<typename PrimType_, typename PositionDiff_, typename RotationDiff_>
 inline static void convertFromRosGeometryMsg(
-  const geometry_msgs::Twist & geometryTwistMsg,
+  const geometry_msgs::msg::Twist & geometryTwistMsg,
   kindr::Twist<PrimType_, PositionDiff_, RotationDiff_> & twist)
 {
   convertFromRosGeometryMsg(geometryTwistMsg.linear, twist.getTranslationalVelocity());
@@ -56,7 +56,7 @@ inline static void convertFromRosGeometryMsg(
 template<typename PrimType_, typename PositionDiff_, typename RotationDiff_>
 inline static void convertToRosGeometryMsg(
   const kindr::Twist<PrimType_, PositionDiff_, RotationDiff_> & twist,
-  geometry_msgs::Twist & geometryTwistMsg)
+  geometry_msgs::msg::Twist & geometryTwistMsg)
 {
   convertToRosGeometryMsg(twist.getTranslationalVelocity(), geometryTwistMsg.linear);
   convertToRosGeometryMsg(twist.getRotationalVelocity(), geometryTwistMsg.angular);

--- a/kindr_ros/include/kindr_ros/RosTfPose.hpp
+++ b/kindr_ros/include/kindr_ros/RosTfPose.hpp
@@ -34,7 +34,10 @@
 #include <kindr/Core>
 
 // ros
-#include <tf/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Vector3.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
 
 
 namespace kindr_ros
@@ -43,7 +46,7 @@ namespace kindr_ros
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertFromRosTf(
-  const tf::Transform & tfTransform,
+  const tf2::Transform & tfTransform,
   kindr::HomogeneousTransformation<PrimType_, Position_,
   Rotation_> & pose)
 {
@@ -53,9 +56,9 @@ inline static void convertFromRosTf(
   // This is the definition of TF.
   typedef kindr::RotationMatrix<PrimType_> RotationMatrixTfLike;
 
-  const tf::Vector3 & rowX = tfTransform.getBasis().getRow(0);
-  const tf::Vector3 & rowY = tfTransform.getBasis().getRow(1);
-  const tf::Vector3 & rowZ = tfTransform.getBasis().getRow(2);
+  const tf2::Vector3 & rowX = tfTransform.getBasis().getRow(0);
+  const tf2::Vector3 & rowY = tfTransform.getBasis().getRow(1);
+  const tf2::Vector3 & rowZ = tfTransform.getBasis().getRow(2);
 
   RotationMatrixTfLike rotation;
   rotation.setMatrix(
@@ -72,32 +75,32 @@ inline static void convertFromRosTf(
 }
 
 template<typename Rotation_>
-inline static void convertToRosTfQuaternion(tf::Quaternion & tfQuat, const Rotation_ & rotation)
+inline static void convertToRosTfQuaternion(tf2::Quaternion & tfQuat, const Rotation_ & rotation)
 {
   const auto quat = kindr::RotationQuaternion<typename Rotation_::Scalar>(rotation);
-  tfQuat = tf::Quaternion(quat.x(), quat.y(), quat.z(), quat.w());
+  tfQuat = tf2::Quaternion(quat.x(), quat.y(), quat.z(), quat.w());
 }
 
 template<typename PrimType_, typename Position_, typename Rotation_>
 inline static void convertToRosTf(
   const kindr::HomogeneousTransformation<PrimType_, Position_,
-  Rotation_> & pose, tf::Transform & tfTransform)
+  Rotation_> & pose, tf2::Transform & tfTransform)
 {
   // This is the definition of TF.
   typedef kindr::RotationMatrix<PrimType_> RotationMatrixTfLike;
   Eigen::Matrix3d rotationMatrix(RotationMatrixTfLike(pose.getRotation()).matrix());
-  tf::Matrix3x3 tfRotationMatrix(rotationMatrix(0, 0), rotationMatrix(0, 1), rotationMatrix(0, 2),
+  tf2::Matrix3x3 tfRotationMatrix(rotationMatrix(0, 0), rotationMatrix(0, 1), rotationMatrix(0, 2),
     rotationMatrix(1, 0), rotationMatrix(1, 1), rotationMatrix(1, 2),
     rotationMatrix(2, 0), rotationMatrix(2, 1), rotationMatrix(2, 2));
   tfTransform.setBasis(tfRotationMatrix);
 
   // less accurate by quaternion:
-//  tf::Quaternion tfQuat;
+//  tf2::Quaternion tfQuat;
 //  convertToRosTfQuaternion(tfQuat, pose.getRotation());
 //  tfTransform.setRotation(tfQuat);
 
   tfTransform.setOrigin(
-    tf::Vector3(
+    tf2::Vector3(
       pose.getPosition().x(),
       pose.getPosition().y(),
       pose.getPosition().z()));

--- a/kindr_ros/include/kindr_ros/RosTfPose.hpp
+++ b/kindr_ros/include/kindr_ros/RosTfPose.hpp
@@ -26,7 +26,8 @@
  *
 */
 
-#pragma once
+#ifndef KINDR_ROS__ROSTFPOSE_HPP_
+#define KINDR_ROS__ROSTFPOSE_HPP_
 
 
 // kindr
@@ -36,11 +37,15 @@
 #include <tf/LinearMath/Transform.h>
 
 
-namespace kindr_ros {
+namespace kindr_ros
+{
 
 
 template<typename PrimType_, typename Position_, typename Rotation_>
-inline static void convertFromRosTf(const tf::Transform& tfTransform, kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_>& pose)
+inline static void convertFromRosTf(
+  const tf::Transform & tfTransform,
+  kindr::HomogeneousTransformation<PrimType_, Position_,
+  Rotation_> & pose)
 {
   typedef Position_ Position;
   typedef Rotation_ Rotation;
@@ -48,39 +53,42 @@ inline static void convertFromRosTf(const tf::Transform& tfTransform, kindr::Hom
   // This is the definition of TF.
   typedef kindr::RotationMatrix<PrimType_> RotationMatrixTfLike;
 
-  const tf::Vector3& rowX = tfTransform.getBasis().getRow(0);
-  const tf::Vector3& rowY = tfTransform.getBasis().getRow(1);
-  const tf::Vector3& rowZ = tfTransform.getBasis().getRow(2);
+  const tf::Vector3 & rowX = tfTransform.getBasis().getRow(0);
+  const tf::Vector3 & rowY = tfTransform.getBasis().getRow(1);
+  const tf::Vector3 & rowZ = tfTransform.getBasis().getRow(2);
 
   RotationMatrixTfLike rotation;
-  rotation.setMatrix(rowX.x(), rowX.y(), rowX.z(),
-                     rowY.x(), rowY.y(), rowY.z(),
-                     rowZ.x(), rowZ.y(), rowZ.z());
+  rotation.setMatrix(
+    rowX.x(), rowX.y(), rowX.z(),
+    rowY.x(), rowY.y(), rowY.z(),
+    rowZ.x(), rowZ.y(), rowZ.z());
 
   Position position(tfTransform.getOrigin().getX(),
-                    tfTransform.getOrigin().getY(),
-                    tfTransform.getOrigin().getZ());
+    tfTransform.getOrigin().getY(),
+    tfTransform.getOrigin().getZ());
 
   pose.getRotation() = Rotation(rotation);
   pose.getPosition() = position;
 }
 
 template<typename Rotation_>
-inline static void convertToRosTfQuaternion(tf::Quaternion& tfQuat, const Rotation_& rotation)
+inline static void convertToRosTfQuaternion(tf::Quaternion & tfQuat, const Rotation_ & rotation)
 {
   const auto quat = kindr::RotationQuaternion<typename Rotation_::Scalar>(rotation);
   tfQuat = tf::Quaternion(quat.x(), quat.y(), quat.z(), quat.w());
 }
 
 template<typename PrimType_, typename Position_, typename Rotation_>
-inline static void convertToRosTf(const kindr::HomogeneousTransformation<PrimType_, Position_, Rotation_>& pose, tf::Transform& tfTransform)
+inline static void convertToRosTf(
+  const kindr::HomogeneousTransformation<PrimType_, Position_,
+  Rotation_> & pose, tf::Transform & tfTransform)
 {
   // This is the definition of TF.
   typedef kindr::RotationMatrix<PrimType_> RotationMatrixTfLike;
   Eigen::Matrix3d rotationMatrix(RotationMatrixTfLike(pose.getRotation()).matrix());
-  tf::Matrix3x3 tfRotationMatrix(rotationMatrix(0,0), rotationMatrix(0,1), rotationMatrix(0,2),
-                                 rotationMatrix(1,0), rotationMatrix(1,1), rotationMatrix(1,2),
-                                 rotationMatrix(2,0), rotationMatrix(2,1), rotationMatrix(2,2));
+  tf::Matrix3x3 tfRotationMatrix(rotationMatrix(0, 0), rotationMatrix(0, 1), rotationMatrix(0, 2),
+    rotationMatrix(1, 0), rotationMatrix(1, 1), rotationMatrix(1, 2),
+    rotationMatrix(2, 0), rotationMatrix(2, 1), rotationMatrix(2, 2));
   tfTransform.setBasis(tfRotationMatrix);
 
   // less accurate by quaternion:
@@ -88,10 +96,14 @@ inline static void convertToRosTf(const kindr::HomogeneousTransformation<PrimTyp
 //  convertToRosTfQuaternion(tfQuat, pose.getRotation());
 //  tfTransform.setRotation(tfQuat);
 
-  tfTransform.setOrigin(tf::Vector3(pose.getPosition().x(),
-                                    pose.getPosition().y(),
-                                    pose.getPosition().z()));
+  tfTransform.setOrigin(
+    tf::Vector3(
+      pose.getPosition().x(),
+      pose.getPosition().y(),
+      pose.getPosition().z()));
 }
 
 
-} // namespace kindr_ros
+}  // namespace kindr_ros
+
+#endif  // KINDR_ROS__ROSTFPOSE_HPP_

--- a/kindr_ros/include/kindr_ros/kindr_ros.hpp
+++ b/kindr_ros/include/kindr_ros/kindr_ros.hpp
@@ -32,10 +32,13 @@
  *      Author: gech
  */
 
-#pragma once
+#ifndef KINDR_ROS__KINDR_ROS_HPP_
+#define KINDR_ROS__KINDR_ROS_HPP_
 
 #include "kindr_ros/RosGeometryMsgPhysicalQuantities.hpp"
 #include "kindr_ros/RosGeometryMsgPose.hpp"
 #include "kindr_ros/RosGeometryMsgTwist.hpp"
 #include "kindr_ros/RosGeometryMsgRotation.hpp"
 #include "kindr_ros/RosTfPose.hpp"
+
+#endif  // KINDR_ROS__KINDR_ROS_HPP_

--- a/kindr_ros/package.xml
+++ b/kindr_ros/package.xml
@@ -12,7 +12,7 @@
 
   <author email="cgehring@anybotics.com">Christian Gehring</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>kindr</depend>
   <depend>geometry_msgs</depend>
@@ -20,5 +20,10 @@
 
   <build_export_depend>eigen</build_export_depend>
 
-  <test_depend>gtest</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
 </package>

--- a/kindr_ros/package.xml
+++ b/kindr_ros/package.xml
@@ -13,15 +13,19 @@
   <author email="cgehring@anybotics.com">Christian Gehring</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
 
   <depend>kindr</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>
-
-  <build_export_depend>eigen</build_export_depend>
+  <build_depend>eigen</build_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
+
+  <build_export_depend>eigen</build_export_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/kindr_ros/package.xml
+++ b/kindr_ros/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>kindr</depend>
   <depend>geometry_msgs</depend>
-  <depend>tf</depend>
+  <depend>tf2</depend>
   <build_export_depend>eigen</build_export_depend>
   <test_depend>gtest</test_depend>
 <!--   <test_depend>cmake_code_coverage</test_depend> -->

--- a/kindr_ros/package.xml
+++ b/kindr_ros/package.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>kindr_ros</name>
   <version>0.3.4</version>
   <description>The kindr_ros package</description>
   <maintainer email="rdiethelm@anybotics.com">Remo Diethelm</maintainer>
   <maintainer email="pleemann@anybotics.com">Philipp Leemann</maintainer>
+
   <license>BSD</license>
+  <url type="website">https://github.com/anybotics/kindr_ros</url>
+
   <author email="cgehring@anybotics.com">Christian Gehring</author>
-  <url>https://github.com/anybotics/kindr_ros</url>
+
   <buildtool_depend>catkin</buildtool_depend>
+
   <depend>kindr</depend>
   <depend>geometry_msgs</depend>
   <depend>tf2</depend>
+
   <build_export_depend>eigen</build_export_depend>
+
   <test_depend>gtest</test_depend>
-<!--   <test_depend>cmake_code_coverage</test_depend> -->
 </package>

--- a/kindr_ros/test/RosGeometryMsgPhysicalQuantitiesTest.cpp
+++ b/kindr_ros/test/RosGeometryMsgPhysicalQuantitiesTest.cpp
@@ -30,9 +30,6 @@
 #include <Eigen/Core>
 #include <gtest/gtest.h>
 
-// ROS
-#include <geometry_msgs/Pose.h>
-
 #include <iostream>
 
 #include "kindr_ros/RosGeometryMsgPhysicalQuantities.hpp"
@@ -44,7 +41,7 @@ TEST(RosGeometryMsgVectorEigen, convertFromRosGeometryMsg)
 {
   const kindr::VectorTypeless3D referenceVector(-9.12, -25.5, 0.6);
 
-  geometry_msgs::Vector3 geometryVector3Msg;
+  geometry_msgs::msg::Vector3 geometryVector3Msg;
   geometryVector3Msg.x = referenceVector.x();
   geometryVector3Msg.y = referenceVector.y();
   geometryVector3Msg.z = referenceVector.z();
@@ -63,7 +60,7 @@ TEST(RosGeometryMsgVectorEigen, convertToRosGeometryMsg)
 
   kindr::VectorTypeless3D vector(referenceVector);
 
-  geometry_msgs::Vector3 geometryVectorMsg;
+  geometry_msgs::msg::Vector3 geometryVectorMsg;
   kindr_ros::convertToRosGeometryMsg(vector, geometryVectorMsg);
 
   EXPECT_NEAR(geometryVectorMsg.x, referenceVector.x(), 1e-8);
@@ -75,7 +72,7 @@ TEST(RosGeometryMsgPositionEigen, convertFromRosGeometryPoint32Msg)
 {
   const kindr::Position3F referenceTranslation(-9.3, 2.5, 5.6);
 
-  geometry_msgs::Point32 geometryPointMsg;
+  geometry_msgs::msg::Point32 geometryPointMsg;
   geometryPointMsg.x = referenceTranslation.x();
   geometryPointMsg.y = referenceTranslation.y();
   geometryPointMsg.z = referenceTranslation.z();
@@ -94,7 +91,7 @@ TEST(RosGeometryMsgPositionEigen, convertToRosGeometryPoint32Msg)
 
   kindr::Position3F position(referenceTranslation);
 
-  geometry_msgs::Point32 geometryPointMsg;
+  geometry_msgs::msg::Point32 geometryPointMsg;
   kindr_ros::convertToRosGeometryMsg(position, geometryPointMsg);
 
   EXPECT_NEAR(geometryPointMsg.x, referenceTranslation.x(), 1e-8);
@@ -106,7 +103,7 @@ TEST(RosGeometryMsgPositionEigen, convertFromRosGeometryPointMsg)
 {
   const kindr::Position3D referenceTranslation(19.3, -2.5, 5.6);
 
-  geometry_msgs::Point geometryPointMsg;
+  geometry_msgs::msg::Point geometryPointMsg;
   geometryPointMsg.x = referenceTranslation.x();
   geometryPointMsg.y = referenceTranslation.y();
   geometryPointMsg.z = referenceTranslation.z();
@@ -125,7 +122,7 @@ TEST(RosGeometryMsgPositionEigen, convertToRosGeometryPointMsg)
 
   kindr::Position3D position(referenceTranslation);
 
-  geometry_msgs::Point geometryPointMsg;
+  geometry_msgs::msg::Point geometryPointMsg;
   kindr_ros::convertToRosGeometryMsg(position, geometryPointMsg);
 
   EXPECT_NEAR(geometryPointMsg.x, referenceTranslation.x(), 1e-8);

--- a/kindr_ros/test/RosGeometryMsgPhysicalQuantitiesTest.cpp
+++ b/kindr_ros/test/RosGeometryMsgPhysicalQuantitiesTest.cpp
@@ -26,19 +26,18 @@
  *
 */
 
-#include <iostream>
 
 #include <Eigen/Core>
-
 #include <gtest/gtest.h>
-
-#include "kindr_ros/RosGeometryMsgPhysicalQuantities.hpp"
-#include "kindr/phys_quant/PhysicalQuantities.hpp"
-#include "kindr/common/gtest_eigen.hpp"
 
 // ROS
 #include <geometry_msgs/Pose.h>
 
+#include <iostream>
+
+#include "kindr_ros/RosGeometryMsgPhysicalQuantities.hpp"
+#include "kindr/phys_quant/PhysicalQuantities.hpp"
+#include "kindr/common/gtest_eigen.hpp"
 
 
 TEST(RosGeometryMsgVectorEigen, convertFromRosGeometryMsg)
@@ -53,7 +52,9 @@ TEST(RosGeometryMsgVectorEigen, convertFromRosGeometryMsg)
   kindr::VectorTypeless3D vector;
   kindr_ros::convertFromRosGeometryMsg(geometryVector3Msg, vector);
 
-  kindr::expectNear(vector.toImplementation(), referenceVector.toImplementation(), 1e-8, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    vector.toImplementation(),
+    referenceVector.toImplementation(), 1e-8, KINDR_SOURCE_FILE_POS);
 }
 
 TEST(RosGeometryMsgVectorEigen, convertToRosGeometryMsg)
@@ -82,7 +83,9 @@ TEST(RosGeometryMsgPositionEigen, convertFromRosGeometryPoint32Msg)
   kindr::Position3F position;
   kindr_ros::convertFromRosGeometryMsg(geometryPointMsg, position);
 
-  kindr::expectNear(position.toImplementation(), referenceTranslation.toImplementation(), 1e-8, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    position.toImplementation(),
+    referenceTranslation.toImplementation(), 1e-8, KINDR_SOURCE_FILE_POS);
 }
 
 TEST(RosGeometryMsgPositionEigen, convertToRosGeometryPoint32Msg)
@@ -111,7 +114,9 @@ TEST(RosGeometryMsgPositionEigen, convertFromRosGeometryPointMsg)
   kindr::Position3D position;
   kindr_ros::convertFromRosGeometryMsg(geometryPointMsg, position);
 
-  kindr::expectNear(position.toImplementation(), referenceTranslation.toImplementation(), 1e-8, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    position.toImplementation(),
+    referenceTranslation.toImplementation(), 1e-8, KINDR_SOURCE_FILE_POS);
 }
 
 TEST(RosGeometryMsgPositionEigen, convertToRosGeometryPointMsg)

--- a/kindr_ros/test/RosGeometryMsgPoseTest.cpp
+++ b/kindr_ros/test/RosGeometryMsgPoseTest.cpp
@@ -30,7 +30,7 @@
 #include <gtest/gtest.h>
 
 // ROS
-#include <geometry_msgs/Pose.h>
+#include <geometry_msgs/msg/pose.hpp>
 
 #include <iostream>
 
@@ -44,7 +44,7 @@ TEST(RosGeometryMsgPoseEigen, convertFromRosGeometryMsg)
   const kindr::Position3D referenceTranslation(0.3, -1.5, 0.6);
   const kindr::RotationQuaternionPD referenceQuaternion(0.113, 0.071, -0.924, 0.35835);
 
-  geometry_msgs::Pose geometryPoseMsg;
+  geometry_msgs::msg::Pose geometryPoseMsg;
   geometryPoseMsg.orientation.x = referenceQuaternion.x();
   geometryPoseMsg.orientation.y = referenceQuaternion.y();
   geometryPoseMsg.orientation.z = referenceQuaternion.z();
@@ -71,7 +71,7 @@ TEST(RosGeometryMsgPoseEigen, convertToRosGeometryMsg)
   pose.getPosition() = referenceTranslation;
   pose.getRotation() = referenceQuaternion;
 
-  geometry_msgs::Pose geometryPoseMsg;
+  geometry_msgs::msg::Pose geometryPoseMsg;
   kindr_ros::convertToRosGeometryMsg(pose, geometryPoseMsg);
 
   EXPECT_NEAR(geometryPoseMsg.orientation.x, referenceQuaternion.x(), 1e-8);
@@ -88,7 +88,7 @@ TEST(RosGeometryMsgTransformationEigen, convertFromRosGeometryMsg)
   const kindr::Position3D referenceTranslation(0.12, 1.5, 0.6);
   const kindr::RotationQuaternionPD referenceQuaternion(0.949, 0.133, 0.169, 0.230541);
 
-  geometry_msgs::Transform geometryTransformMsg;
+  geometry_msgs::msg::Transform geometryTransformMsg;
   geometryTransformMsg.rotation.x = referenceQuaternion.x();
   geometryTransformMsg.rotation.y = referenceQuaternion.y();
   geometryTransformMsg.rotation.z = referenceQuaternion.z();
@@ -115,7 +115,7 @@ TEST(RosGeometryMsgTransformationEigen, convertToRosGeometryMsg)
   transformation.getPosition() = referenceTranslation;
   transformation.getRotation() = referenceQuaternion;
 
-  geometry_msgs::Transform geometryTransformMsg;
+  geometry_msgs::msg::Transform geometryTransformMsg;
   kindr_ros::convertToRosGeometryMsg(transformation, geometryTransformMsg);
 
   EXPECT_NEAR(geometryTransformMsg.rotation.x, referenceQuaternion.x(), 1e-8);

--- a/kindr_ros/test/RosGeometryMsgPoseTest.cpp
+++ b/kindr_ros/test/RosGeometryMsgPoseTest.cpp
@@ -26,18 +26,18 @@
  *
 */
 
-#include <iostream>
-
 #include <Eigen/Core>
-
 #include <gtest/gtest.h>
+
+// ROS
+#include <geometry_msgs/Pose.h>
+
+#include <iostream>
 
 #include "kindr_ros/RosGeometryMsgPose.hpp"
 #include "kindr/poses/Pose.hpp"
 #include "kindr/common/gtest_eigen.hpp"
 
-// ROS
-#include <geometry_msgs/Pose.h>
 
 TEST(RosGeometryMsgPoseEigen, convertFromRosGeometryMsg)
 {
@@ -56,8 +56,9 @@ TEST(RosGeometryMsgPoseEigen, convertFromRosGeometryMsg)
   kindr::HomogeneousTransformationPosition3RotationQuaternionD pose;
   kindr_ros::convertFromRosGeometryMsg(geometryPoseMsg, pose);
 
-  kindr::expectNear(pose.getPosition().toImplementation(), referenceTranslation.toImplementation(), 1e-4,
-                     KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    pose.getPosition().toImplementation(), referenceTranslation.toImplementation(), 1e-4,
+    KINDR_SOURCE_FILE_POS);
   EXPECT_TRUE(pose.getRotation().isNear(referenceQuaternion, 1e-8));
 }
 
@@ -99,8 +100,9 @@ TEST(RosGeometryMsgTransformationEigen, convertFromRosGeometryMsg)
   kindr::HomogeneousTransformationPosition3RotationQuaternionD transformation;
   kindr_ros::convertFromRosGeometryMsg(geometryTransformMsg, transformation);
 
-  kindr::expectNear(transformation.getPosition().toImplementation(), referenceTranslation.toImplementation(), 1e-4,
-                     KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    transformation.getPosition().toImplementation(), referenceTranslation.toImplementation(), 1e-4,
+    KINDR_SOURCE_FILE_POS);
   EXPECT_TRUE(transformation.getRotation().isNear(referenceQuaternion, 1e-8));
 }
 

--- a/kindr_ros/test/RosGeometryMsgRotationTest.cpp
+++ b/kindr_ros/test/RosGeometryMsgRotationTest.cpp
@@ -30,7 +30,7 @@
 #include <gtest/gtest.h>
 
 // ROS
-#include <geometry_msgs/Quaternion.h>
+#include <geometry_msgs/msg/quaternion.hpp>
 
 #include <iostream>
 
@@ -43,7 +43,7 @@ TEST(RosGeometryMsgRotationQuaternionEigen, convertFromRosGeometryMsg)
 {
   const kindr::RotationQuaternionPD referenceQuaternion(0.113, 0.071, -0.924, 0.35835);
 
-  geometry_msgs::Quaternion geometryQuaternionMsg;
+  geometry_msgs::msg::Quaternion geometryQuaternionMsg;
   geometryQuaternionMsg.x = referenceQuaternion.x();
   geometryQuaternionMsg.y = referenceQuaternion.y();
   geometryQuaternionMsg.z = referenceQuaternion.z();
@@ -61,7 +61,7 @@ TEST(RosGeometryMsgRotationQuaternionEigen, convertToRosGeometryMsg)
 
   kindr::RotationQuaternionPD rotationQuaternion(referenceQuaternion);
 
-  geometry_msgs::Quaternion geometryQuaternionMsg;
+  geometry_msgs::msg::Quaternion geometryQuaternionMsg;
   kindr_ros::convertToRosGeometryMsg(rotationQuaternion, geometryQuaternionMsg);
 
   EXPECT_NEAR(geometryQuaternionMsg.x, referenceQuaternion.x(), 1e-8);

--- a/kindr_ros/test/RosGeometryMsgRotationTest.cpp
+++ b/kindr_ros/test/RosGeometryMsgRotationTest.cpp
@@ -26,18 +26,17 @@
  *
 */
 
-#include <iostream>
-
 #include <Eigen/Core>
-
 #include <gtest/gtest.h>
+
+// ROS
+#include <geometry_msgs/Quaternion.h>
+
+#include <iostream>
 
 #include "kindr_ros/RosGeometryMsgRotation.hpp"
 #include "kindr/poses/Pose.hpp"
 #include "kindr/common/gtest_eigen.hpp"
-
-// ROS
-#include <geometry_msgs/Quaternion.h>
 
 
 TEST(RosGeometryMsgRotationQuaternionEigen, convertFromRosGeometryMsg)

--- a/kindr_ros/test/RosTfPoseTest.cpp
+++ b/kindr_ros/test/RosTfPoseTest.cpp
@@ -26,19 +26,18 @@
  *
 */
 
-#include <iostream>
-
 #include <Eigen/Core>
-
 #include <gtest/gtest.h>
+
+// ROS
+#include <tf/LinearMath/Transform.h>
+
+#include <iostream>
 
 #include "kindr_ros/RosTfPose.hpp"
 #include "kindr/poses/Pose.hpp"
 #include "kindr/rotations/Rotation.hpp"
 #include "kindr/common/gtest_eigen.hpp"
-
-// ROS
-#include <tf/LinearMath/Transform.h>
 
 
 TEST(RosTfPoseEigen, convertFromRosTf)
@@ -47,11 +46,22 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::RotationMatrixD referenceRotationMatrix(referenceQuaternion);
   const Eigen::Matrix3d referenceRotationMatrixEigen(referenceRotationMatrix.matrix());
   const kindr::Position3D referenceTranslation(0.3, -1.5, 0.6);
-  const tf::Vector3 referenceOriginTf(referenceTranslation.x(), referenceTranslation.y(), referenceTranslation.z());
-  const tf::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(0,0), referenceRotationMatrixEigen(0,1), referenceRotationMatrixEigen(0,2),
-                                       referenceRotationMatrixEigen(1,0), referenceRotationMatrixEigen(1,1), referenceRotationMatrixEigen(1,2),
-                                       referenceRotationMatrixEigen(2,0), referenceRotationMatrixEigen(2,1), referenceRotationMatrixEigen(2,2));
-  const tf::Quaternion referenceQuaternionTf(referenceQuaternion.x(), referenceQuaternion.y(), referenceQuaternion.z(), referenceQuaternion.w());
+  const tf::Vector3 referenceOriginTf(referenceTranslation.x(),
+    referenceTranslation.y(), referenceTranslation.z());
+  const tf::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(
+      0,
+      0), referenceRotationMatrixEigen(
+      0, 1), referenceRotationMatrixEigen(0, 2),
+    referenceRotationMatrixEigen(1, 0), referenceRotationMatrixEigen(
+      1,
+      1), referenceRotationMatrixEigen(
+      1, 2),
+    referenceRotationMatrixEigen(2, 0), referenceRotationMatrixEigen(
+      2,
+      1), referenceRotationMatrixEigen(
+      2, 2));
+  const tf::Quaternion referenceQuaternionTf(referenceQuaternion.x(),
+    referenceQuaternion.y(), referenceQuaternion.z(), referenceQuaternion.w());
 
   kindr::HomogeneousTransformationPosition3RotationQuaternionD pose;
   tf::Transform tfTransform;
@@ -60,21 +70,29 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   // Setting & getting identity
   tfTransform.setIdentity();
   kindr_ros::convertFromRosTf(tfTransform, pose);
-  kindr::expectNear(pose.getTransformationMatrix(), Eigen::Matrix4d::Identity(), 1e-4, KINDR_SOURCE_FILE_POS);
-  kindr::expectNear(pose.getPosition().toImplementation(), kindr::Position3D::Zero().toImplementation(), 1e-4, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    pose.getTransformationMatrix(),
+    Eigen::Matrix4d::Identity(), 1e-4, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    pose.getPosition().toImplementation(),
+    kindr::Position3D::Zero().toImplementation(), 1e-4, KINDR_SOURCE_FILE_POS);
 
   // Setting & getting with rotation matrix
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
   kindr_ros::convertFromRosTf(tfTransform, pose);
-  kindr::expectNear(kindr::RotationMatrixD(pose.getRotation()).matrix(),
-                     referenceRotationMatrix.matrix(), 1e-4, KINDR_SOURCE_FILE_POS);
-  kindr::expectNear(pose.getPosition().toImplementation(), referenceTranslation.toImplementation(), 1e-4, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    kindr::RotationMatrixD(pose.getRotation()).matrix(),
+    referenceRotationMatrix.matrix(), 1e-4, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    pose.getPosition().toImplementation(),
+    referenceTranslation.toImplementation(), 1e-4, KINDR_SOURCE_FILE_POS);
 
   // Identity transformation
   const kindr::Position3D testVector1(6.6, 0.0, -3.2);
   tfTransform.setIdentity();
-  tf::Vector3 tfTestVectorTransformed1 = tfTransform(tf::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
+  tf::Vector3 tfTestVectorTransformed1 =
+    tfTransform(tf::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed1 = pose.transform(testVector1);
   EXPECT_NEAR(testVectorTransformed1.x(), testVector1.x(), 1e-8);
@@ -85,7 +103,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector2(-18.4, 41.4, -0.2);
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
-  tf::Vector3 tfTestVectorTransformed2 = tfTransform(tf::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
+  tf::Vector3 tfTestVectorTransformed2 =
+    tfTransform(tf::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed2 = pose.transform(testVector2);
   EXPECT_NEAR(testVectorTransformed2.x(), tfTestVectorTransformed2.x(), 1e-2);
@@ -97,7 +116,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
   tfTransformInverse = tfTransform.inverse();
-  tf::Vector3 tfTestVectorTransformed3 = tfTransformInverse(tf::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
+  tf::Vector3 tfTestVectorTransformed3 =
+    tfTransformInverse(tf::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed3 = pose.inverseTransform(testVector3);
   EXPECT_NEAR(testVectorTransformed3.x(), tfTestVectorTransformed3.x(), 1e-2);
@@ -108,7 +128,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector4(0.0, 0.0, 0.0);
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
-  tf::Vector3 tfTestVectorTransformed4 = tfTransform(tf::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
+  tf::Vector3 tfTestVectorTransformed4 =
+    tfTransform(tf::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed4 = pose.transform(testVector4);
   EXPECT_NEAR(testVectorTransformed4.x(), tfTestVectorTransformed4.x(), 1e-4);
@@ -119,7 +140,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector5(1.0, 3.0, -4.0);
   tfTransform.setIdentity();
   tfTransform.setBasis(referenceBasisTf);
-  tf::Vector3 tfTestVectorTransformed5 = tfTransform(tf::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
+  tf::Vector3 tfTestVectorTransformed5 =
+    tfTransform(tf::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed5 = pose.transform(testVector5);
   EXPECT_NEAR(testVectorTransformed5.x(), tfTestVectorTransformed5.x(), 1e-2);
@@ -130,7 +152,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector6(0.0, 1.0, -44.0);
   tfTransform.setIdentity();
   tfTransform.setOrigin(referenceOriginTf);
-  tf::Vector3 tfTestVectorTransformed6 = tfTransform(tf::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
+  tf::Vector3 tfTestVectorTransformed6 =
+    tfTransform(tf::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed6 = pose.transform(testVector6);
   EXPECT_NEAR(testVectorTransformed6.x(), tfTestVectorTransformed6.x(), 1e-8);
@@ -153,7 +176,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.setIdentity();
   kindr::Position3D testVector1Transformed = pose.transform(testVector1);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector1Transformed = tfTransform(tf::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
+  tf::Vector3 tfTestVector1Transformed =
+    tfTransform(tf::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
   EXPECT_NEAR(tfTestVector1Transformed.x(), testVector1.x(), 1e-8);
   EXPECT_NEAR(tfTestVector1Transformed.y(), testVector1.y(), 1e-8);
   EXPECT_NEAR(tfTestVector1Transformed.z(), testVector1.z(), 1e-8);
@@ -164,7 +188,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getRotation() = referenceQuaternion;
   kindr::Position3D testVector2Transformed = pose.transform(testVector2);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector2Transformed = tfTransform(tf::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
+  tf::Vector3 tfTestVector2Transformed =
+    tfTransform(tf::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
   EXPECT_NEAR(tfTestVector2Transformed.x(), testVector2Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector2Transformed.y(), testVector2Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector2Transformed.z(), testVector2Transformed.z(), 1e-8);
@@ -176,7 +201,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   kindr::Position3D testVector3Transformed = pose.inverseTransform(testVector3);
   kindr_ros::convertToRosTf(pose, tfTransform);
   tfTransformInverse = tfTransform.inverse();
-  tf::Vector3 tfTestVector3Transformed = tfTransformInverse(tf::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
+  tf::Vector3 tfTestVector3Transformed =
+    tfTransformInverse(tf::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
   EXPECT_NEAR(tfTestVector3Transformed.x(), testVector3Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector3Transformed.y(), testVector3Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector3Transformed.z(), testVector3Transformed.z(), 1e-8);
@@ -187,7 +213,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getRotation() = referenceQuaternion;
   kindr::Position3D testVector4Transformed = pose.transform(testVector4);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector4Transformed = tfTransform(tf::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
+  tf::Vector3 tfTestVector4Transformed =
+    tfTransform(tf::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
   EXPECT_NEAR(tfTestVector4Transformed.x(), testVector4Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector4Transformed.y(), testVector4Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector4Transformed.z(), testVector4Transformed.z(), 1e-8);
@@ -198,7 +225,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getRotation() = referenceQuaternion;
   kindr::Position3D testVector5Transformed = pose.transform(testVector5);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector5Transformed = tfTransform(tf::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
+  tf::Vector3 tfTestVector5Transformed =
+    tfTransform(tf::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
   EXPECT_NEAR(tfTestVector5Transformed.x(), testVector5Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector5Transformed.y(), testVector5Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector5Transformed.z(), testVector5Transformed.z(), 1e-8);
@@ -209,7 +237,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getPosition() = referenceTranslation;
   kindr::Position3D testVector6Transformed = pose.transform(testVector6);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector6Transformed = tfTransform(tf::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
+  tf::Vector3 tfTestVector6Transformed =
+    tfTransform(tf::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
   EXPECT_NEAR(tfTestVector6Transformed.x(), testVector6Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector6Transformed.y(), testVector6Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector6Transformed.z(), testVector6Transformed.z(), 1e-8);
@@ -221,11 +250,22 @@ TEST(RosTfPoseEigen, convertTwoWays)
   const kindr::RotationMatrixD referenceRotationMatrix(referenceQuaternion);
   const Eigen::Matrix3d referenceRotationMatrixEigen(referenceRotationMatrix.matrix());
   const kindr::Position3D referenceTranslation(13.3, 2.6, -7.6);
-  const tf::Vector3 referenceOriginTf(referenceTranslation.x(), referenceTranslation.y(), referenceTranslation.z());
-  const tf::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(0,0), referenceRotationMatrixEigen(0,1), referenceRotationMatrixEigen(0,2),
-                                       referenceRotationMatrixEigen(1,0), referenceRotationMatrixEigen(1,1), referenceRotationMatrixEigen(1,2),
-                                       referenceRotationMatrixEigen(2,0), referenceRotationMatrixEigen(2,1), referenceRotationMatrixEigen(2,2));
-  const tf::Quaternion referenceQuaternionTf(referenceQuaternion.x(), referenceQuaternion.y(), referenceQuaternion.z(), referenceQuaternion.w());
+  const tf::Vector3 referenceOriginTf(referenceTranslation.x(),
+    referenceTranslation.y(), referenceTranslation.z());
+  const tf::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(
+      0,
+      0), referenceRotationMatrixEigen(
+      0, 1), referenceRotationMatrixEigen(0, 2),
+    referenceRotationMatrixEigen(1, 0), referenceRotationMatrixEigen(
+      1,
+      1), referenceRotationMatrixEigen(
+      1, 2),
+    referenceRotationMatrixEigen(2, 0), referenceRotationMatrixEigen(
+      2,
+      1), referenceRotationMatrixEigen(
+      2, 2));
+  const tf::Quaternion referenceQuaternionTf(referenceQuaternion.x(),
+    referenceQuaternion.y(), referenceQuaternion.z(), referenceQuaternion.w());
 
   kindr::HomogeneousTransformationPosition3RotationQuaternionD pose, poseConverted;
   tf::Transform tfTransform, tfTransformConverted;
@@ -235,23 +275,42 @@ TEST(RosTfPoseEigen, convertTwoWays)
   pose.getRotation() = referenceQuaternion;
   kindr_ros::convertToRosTf(pose, tfTransform);
   kindr_ros::convertFromRosTf(tfTransform, poseConverted);
-  kindr::expectNear(poseConverted.getTransformationMatrix(),
-                     pose.getTransformationMatrix(), 1e-4, KINDR_SOURCE_FILE_POS);
+  kindr::expectNear(
+    poseConverted.getTransformationMatrix(),
+    pose.getTransformationMatrix(), 1e-4, KINDR_SOURCE_FILE_POS);
 
   // TF -> Kindr -> TF
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr_ros::convertToRosTf(pose, tfTransformConverted);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(0).x(), tfTransform.getBasis().getRow(0).x(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(0).y(), tfTransform.getBasis().getRow(0).y(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(0).z(), tfTransform.getBasis().getRow(0).z(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(1).x(), tfTransform.getBasis().getRow(1).x(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(1).y(), tfTransform.getBasis().getRow(1).y(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(1).z(), tfTransform.getBasis().getRow(1).z(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(2).x(), tfTransform.getBasis().getRow(2).x(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(2).y(), tfTransform.getBasis().getRow(2).y(), 1e-8);
-  EXPECT_NEAR(tfTransformConverted.getBasis().getRow(2).z(), tfTransform.getBasis().getRow(2).z(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(0).x(), tfTransform.getBasis().getRow(
+      0).x(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(0).y(), tfTransform.getBasis().getRow(
+      0).y(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(0).z(), tfTransform.getBasis().getRow(
+      0).z(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(1).x(), tfTransform.getBasis().getRow(
+      1).x(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(1).y(), tfTransform.getBasis().getRow(
+      1).y(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(1).z(), tfTransform.getBasis().getRow(
+      1).z(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(2).x(), tfTransform.getBasis().getRow(
+      2).x(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(2).y(), tfTransform.getBasis().getRow(
+      2).y(), 1e-8);
+  EXPECT_NEAR(
+    tfTransformConverted.getBasis().getRow(2).z(), tfTransform.getBasis().getRow(
+      2).z(), 1e-8);
   EXPECT_NEAR(tfTransformConverted.getOrigin().x(), tfTransform.getOrigin().x(), 1e-8);
   EXPECT_NEAR(tfTransformConverted.getOrigin().y(), tfTransform.getOrigin().y(), 1e-8);
   EXPECT_NEAR(tfTransformConverted.getOrigin().z(), tfTransform.getOrigin().z(), 1e-8);

--- a/kindr_ros/test/RosTfPoseTest.cpp
+++ b/kindr_ros/test/RosTfPoseTest.cpp
@@ -93,8 +93,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   // Identity transformation
   const kindr::Position3D testVector1(6.6, 0.0, -3.2);
   tfTransform.setIdentity();
-  tf2::Vector3 tfTestVectorTransformed1 =
-    tfTransform(tf2::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
+  // tf2::Vector3 tfTestVectorTransformed1 =
+  //   tfTransform(tf2::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed1 = pose.transform(testVector1);
   EXPECT_NEAR(testVectorTransformed1.x(), testVector1.x(), 1e-8);
@@ -176,7 +176,7 @@ TEST(RosTfPoseEigen, convertToRosTf)
   // Identity transformation
   const kindr::Position3D testVector1(0.6, -0.4, -3.2);
   pose.setIdentity();
-  kindr::Position3D testVector1Transformed = pose.transform(testVector1);
+  // kindr::Position3D testVector1Transformed = pose.transform(testVector1);
   kindr_ros::convertToRosTf(pose, tfTransform);
   tf2::Vector3 tfTestVector1Transformed =
     tfTransform(tf2::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));

--- a/kindr_ros/test/RosTfPoseTest.cpp
+++ b/kindr_ros/test/RosTfPoseTest.cpp
@@ -287,32 +287,33 @@ TEST(RosTfPoseEigen, convertTwoWays)
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr_ros::convertToRosTf(pose, tfTransformConverted);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(0).x(), tfTransform.getBasis().getRow(
-      0).x(), 1e-8);
+    tfTransformConverted.getBasis().getRow(0).x(),
+    tfTransform.getBasis().getRow(0).x(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(0).y(), tfTransform.getBasis().getRow(
-      0).y(), 1e-8);
+    tfTransformConverted.getBasis().getRow(0).y(),
+    tfTransform.getBasis().getRow(0).y(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(0).z(), tfTransform.getBasis().getRow(
-      0).z(), 1e-8);
+    tfTransformConverted.getBasis().getRow(0).z(),
+    tfTransform.getBasis().getRow(0).z(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(1).x(), tfTransform.getBasis().getRow(
-      1).x(), 1e-8);
+    tfTransformConverted.getBasis().getRow(1).x(),
+    tfTransform.getBasis().getRow(1).x(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(1).y(), tfTransform.getBasis().getRow(
-      1).y(), 1e-8);
+    tfTransformConverted.getBasis().getRow(1).y(),
+    tfTransform.getBasis().getRow(1).y(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(1).z(), tfTransform.getBasis().getRow(
-      1).z(), 1e-8);
+    tfTransformConverted.getBasis().getRow(1).z(),
+    tfTransform.getBasis().getRow(1).z(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(2).x(), tfTransform.getBasis().getRow(
-      2).x(), 1e-8);
+    tfTransformConverted.getBasis().getRow(2).x(),
+    tfTransform.getBasis().getRow(2).x(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(2).y(), tfTransform.getBasis().getRow(
-      2).y(), 1e-8);
+    tfTransformConverted.getBasis().getRow(2).y(),
+    tfTransform.getBasis().getRow(2).y(), 1e-8);
   EXPECT_NEAR(
-    tfTransformConverted.getBasis().getRow(2).z(), tfTransform.getBasis().getRow(
-      2).z(), 1e-8);
+    tfTransformConverted.getBasis().getRow(2).z(),
+    tfTransform.getBasis().getRow(2).z(), 1e-8);
+
   EXPECT_NEAR(tfTransformConverted.getOrigin().x(), tfTransform.getOrigin().x(), 1e-8);
   EXPECT_NEAR(tfTransformConverted.getOrigin().y(), tfTransform.getOrigin().y(), 1e-8);
   EXPECT_NEAR(tfTransformConverted.getOrigin().z(), tfTransform.getOrigin().z(), 1e-8);

--- a/kindr_ros/test/RosTfPoseTest.cpp
+++ b/kindr_ros/test/RosTfPoseTest.cpp
@@ -30,7 +30,9 @@
 #include <gtest/gtest.h>
 
 // ROS
-#include <tf/LinearMath/Transform.h>
+#include <tf2/LinearMath/Transform.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Vector3.h>
 
 #include <iostream>
 
@@ -46,9 +48,9 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::RotationMatrixD referenceRotationMatrix(referenceQuaternion);
   const Eigen::Matrix3d referenceRotationMatrixEigen(referenceRotationMatrix.matrix());
   const kindr::Position3D referenceTranslation(0.3, -1.5, 0.6);
-  const tf::Vector3 referenceOriginTf(referenceTranslation.x(),
+  const tf2::Vector3 referenceOriginTf(referenceTranslation.x(),
     referenceTranslation.y(), referenceTranslation.z());
-  const tf::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(
+  const tf2::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(
       0,
       0), referenceRotationMatrixEigen(
       0, 1), referenceRotationMatrixEigen(0, 2),
@@ -60,12 +62,12 @@ TEST(RosTfPoseEigen, convertFromRosTf)
       2,
       1), referenceRotationMatrixEigen(
       2, 2));
-  const tf::Quaternion referenceQuaternionTf(referenceQuaternion.x(),
+  const tf2::Quaternion referenceQuaternionTf(referenceQuaternion.x(),
     referenceQuaternion.y(), referenceQuaternion.z(), referenceQuaternion.w());
 
   kindr::HomogeneousTransformationPosition3RotationQuaternionD pose;
-  tf::Transform tfTransform;
-  tf::Transform tfTransformInverse;
+  tf2::Transform tfTransform;
+  tf2::Transform tfTransformInverse;
 
   // Setting & getting identity
   tfTransform.setIdentity();
@@ -91,8 +93,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   // Identity transformation
   const kindr::Position3D testVector1(6.6, 0.0, -3.2);
   tfTransform.setIdentity();
-  tf::Vector3 tfTestVectorTransformed1 =
-    tfTransform(tf::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
+  tf2::Vector3 tfTestVectorTransformed1 =
+    tfTransform(tf2::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed1 = pose.transform(testVector1);
   EXPECT_NEAR(testVectorTransformed1.x(), testVector1.x(), 1e-8);
@@ -103,8 +105,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector2(-18.4, 41.4, -0.2);
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
-  tf::Vector3 tfTestVectorTransformed2 =
-    tfTransform(tf::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
+  tf2::Vector3 tfTestVectorTransformed2 =
+    tfTransform(tf2::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed2 = pose.transform(testVector2);
   EXPECT_NEAR(testVectorTransformed2.x(), tfTestVectorTransformed2.x(), 1e-2);
@@ -116,8 +118,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
   tfTransformInverse = tfTransform.inverse();
-  tf::Vector3 tfTestVectorTransformed3 =
-    tfTransformInverse(tf::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
+  tf2::Vector3 tfTestVectorTransformed3 =
+    tfTransformInverse(tf2::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed3 = pose.inverseTransform(testVector3);
   EXPECT_NEAR(testVectorTransformed3.x(), tfTestVectorTransformed3.x(), 1e-2);
@@ -128,8 +130,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector4(0.0, 0.0, 0.0);
   tfTransform.setOrigin(referenceOriginTf);
   tfTransform.setBasis(referenceBasisTf);
-  tf::Vector3 tfTestVectorTransformed4 =
-    tfTransform(tf::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
+  tf2::Vector3 tfTestVectorTransformed4 =
+    tfTransform(tf2::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed4 = pose.transform(testVector4);
   EXPECT_NEAR(testVectorTransformed4.x(), tfTestVectorTransformed4.x(), 1e-4);
@@ -140,8 +142,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector5(1.0, 3.0, -4.0);
   tfTransform.setIdentity();
   tfTransform.setBasis(referenceBasisTf);
-  tf::Vector3 tfTestVectorTransformed5 =
-    tfTransform(tf::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
+  tf2::Vector3 tfTestVectorTransformed5 =
+    tfTransform(tf2::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed5 = pose.transform(testVector5);
   EXPECT_NEAR(testVectorTransformed5.x(), tfTestVectorTransformed5.x(), 1e-2);
@@ -152,8 +154,8 @@ TEST(RosTfPoseEigen, convertFromRosTf)
   const kindr::Position3D testVector6(0.0, 1.0, -44.0);
   tfTransform.setIdentity();
   tfTransform.setOrigin(referenceOriginTf);
-  tf::Vector3 tfTestVectorTransformed6 =
-    tfTransform(tf::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
+  tf2::Vector3 tfTestVectorTransformed6 =
+    tfTransform(tf2::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
   kindr_ros::convertFromRosTf(tfTransform, pose);
   kindr::Position3D testVectorTransformed6 = pose.transform(testVector6);
   EXPECT_NEAR(testVectorTransformed6.x(), tfTestVectorTransformed6.x(), 1e-8);
@@ -168,16 +170,16 @@ TEST(RosTfPoseEigen, convertToRosTf)
   const kindr::Position3D referenceTranslation(-22.4, 0.31, -4.6);
 
   kindr::HomogeneousTransformationPosition3RotationQuaternionD pose;
-  tf::Transform tfTransform;
-  tf::Transform tfTransformInverse;
+  tf2::Transform tfTransform;
+  tf2::Transform tfTransformInverse;
 
   // Identity transformation
   const kindr::Position3D testVector1(0.6, -0.4, -3.2);
   pose.setIdentity();
   kindr::Position3D testVector1Transformed = pose.transform(testVector1);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector1Transformed =
-    tfTransform(tf::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
+  tf2::Vector3 tfTestVector1Transformed =
+    tfTransform(tf2::Vector3(testVector1.x(), testVector1.y(), testVector1.z()));
   EXPECT_NEAR(tfTestVector1Transformed.x(), testVector1.x(), 1e-8);
   EXPECT_NEAR(tfTestVector1Transformed.y(), testVector1.y(), 1e-8);
   EXPECT_NEAR(tfTestVector1Transformed.z(), testVector1.z(), 1e-8);
@@ -188,8 +190,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getRotation() = referenceQuaternion;
   kindr::Position3D testVector2Transformed = pose.transform(testVector2);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector2Transformed =
-    tfTransform(tf::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
+  tf2::Vector3 tfTestVector2Transformed =
+    tfTransform(tf2::Vector3(testVector2.x(), testVector2.y(), testVector2.z()));
   EXPECT_NEAR(tfTestVector2Transformed.x(), testVector2Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector2Transformed.y(), testVector2Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector2Transformed.z(), testVector2Transformed.z(), 1e-8);
@@ -201,8 +203,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   kindr::Position3D testVector3Transformed = pose.inverseTransform(testVector3);
   kindr_ros::convertToRosTf(pose, tfTransform);
   tfTransformInverse = tfTransform.inverse();
-  tf::Vector3 tfTestVector3Transformed =
-    tfTransformInverse(tf::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
+  tf2::Vector3 tfTestVector3Transformed =
+    tfTransformInverse(tf2::Vector3(testVector3.x(), testVector3.y(), testVector3.z()));
   EXPECT_NEAR(tfTestVector3Transformed.x(), testVector3Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector3Transformed.y(), testVector3Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector3Transformed.z(), testVector3Transformed.z(), 1e-8);
@@ -213,8 +215,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getRotation() = referenceQuaternion;
   kindr::Position3D testVector4Transformed = pose.transform(testVector4);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector4Transformed =
-    tfTransform(tf::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
+  tf2::Vector3 tfTestVector4Transformed =
+    tfTransform(tf2::Vector3(testVector4.x(), testVector4.y(), testVector4.z()));
   EXPECT_NEAR(tfTestVector4Transformed.x(), testVector4Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector4Transformed.y(), testVector4Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector4Transformed.z(), testVector4Transformed.z(), 1e-8);
@@ -225,8 +227,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getRotation() = referenceQuaternion;
   kindr::Position3D testVector5Transformed = pose.transform(testVector5);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector5Transformed =
-    tfTransform(tf::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
+  tf2::Vector3 tfTestVector5Transformed =
+    tfTransform(tf2::Vector3(testVector5.x(), testVector5.y(), testVector5.z()));
   EXPECT_NEAR(tfTestVector5Transformed.x(), testVector5Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector5Transformed.y(), testVector5Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector5Transformed.z(), testVector5Transformed.z(), 1e-8);
@@ -237,8 +239,8 @@ TEST(RosTfPoseEigen, convertToRosTf)
   pose.getPosition() = referenceTranslation;
   kindr::Position3D testVector6Transformed = pose.transform(testVector6);
   kindr_ros::convertToRosTf(pose, tfTransform);
-  tf::Vector3 tfTestVector6Transformed =
-    tfTransform(tf::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
+  tf2::Vector3 tfTestVector6Transformed =
+    tfTransform(tf2::Vector3(testVector6.x(), testVector6.y(), testVector6.z()));
   EXPECT_NEAR(tfTestVector6Transformed.x(), testVector6Transformed.x(), 1e-8);
   EXPECT_NEAR(tfTestVector6Transformed.y(), testVector6Transformed.y(), 1e-8);
   EXPECT_NEAR(tfTestVector6Transformed.z(), testVector6Transformed.z(), 1e-8);
@@ -250,9 +252,9 @@ TEST(RosTfPoseEigen, convertTwoWays)
   const kindr::RotationMatrixD referenceRotationMatrix(referenceQuaternion);
   const Eigen::Matrix3d referenceRotationMatrixEigen(referenceRotationMatrix.matrix());
   const kindr::Position3D referenceTranslation(13.3, 2.6, -7.6);
-  const tf::Vector3 referenceOriginTf(referenceTranslation.x(),
+  const tf2::Vector3 referenceOriginTf(referenceTranslation.x(),
     referenceTranslation.y(), referenceTranslation.z());
-  const tf::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(
+  const tf2::Matrix3x3 referenceBasisTf(referenceRotationMatrixEigen(
       0,
       0), referenceRotationMatrixEigen(
       0, 1), referenceRotationMatrixEigen(0, 2),
@@ -264,11 +266,11 @@ TEST(RosTfPoseEigen, convertTwoWays)
       2,
       1), referenceRotationMatrixEigen(
       2, 2));
-  const tf::Quaternion referenceQuaternionTf(referenceQuaternion.x(),
+  const tf2::Quaternion referenceQuaternionTf(referenceQuaternion.x(),
     referenceQuaternion.y(), referenceQuaternion.z(), referenceQuaternion.w());
 
   kindr::HomogeneousTransformationPosition3RotationQuaternionD pose, poseConverted;
-  tf::Transform tfTransform, tfTransformConverted;
+  tf2::Transform tfTransform, tfTransformConverted;
 
   // Kindr -> TF -> Kindr
   pose.getPosition() = referenceTranslation;

--- a/kindr_ros/test/TfConventionTest.cpp
+++ b/kindr_ros/test/TfConventionTest.cpp
@@ -35,7 +35,9 @@
 #include <gtest/gtest.h>
 #include <kindr/Core>
 #include <kindr/rotations/gtest_rotations.hpp>
-#include <tf/tf.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/LinearMath/Matrix3x3.h>
+#include <tf2/LinearMath/Vector3.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -43,10 +45,10 @@ namespace kindr
 {
 
 template<>
-class RotationConversion<tf::Quaternion, tf::Vector3, double>
+class RotationConversion<tf2::Quaternion, tf2::Vector3, double>
 {
-  typedef tf::Quaternion Rotation;
-  typedef tf::Vector3 Vector;
+  typedef tf2::Quaternion Rotation;
+  typedef tf2::Vector3 Vector;
 
 public:
   inline static void convertToOtherRotation(
@@ -54,7 +56,7 @@ public:
     const kindr::RotationQuaternion<double> & in)
   {
     kindr::RotationQuaternion<double> in2 = in;
-    out = tf::Quaternion(in2.x(), in2.y(), in2.z(), in2.w());
+    out = tf2::Quaternion(in2.x(), in2.y(), in2.z(), in2.w());
   }
 
   inline static void convertToKindr(kindr::RotationQuaternion<double> & out, Rotation & in)
@@ -66,7 +68,7 @@ public:
     Vector & out, Rotation & rot,
     const Eigen::Matrix<double, 3, 1> & in)
   {
-    out = tf::Vector3(in.x(), in.y(), in.z());
+    out = tf2::Vector3(in.x(), in.y(), in.z());
   }
 
   inline static void concatenate(Rotation & res, const Rotation & rot1, const Rotation & rot2)
@@ -78,7 +80,7 @@ public:
     Eigen::Matrix3d & rotationMatrix,
     const Rotation & quaternion)
   {
-    tf::Matrix3x3 tfRotationmatrix;
+    tf2::Matrix3x3 tfRotationmatrix;
     tfRotationmatrix.setRotation(quaternion);
     for (int i = 0; i < 3; i++) {
       rotationMatrix(i, 0) = tfRotationmatrix.getRow(i).x();
@@ -91,7 +93,7 @@ public:
     Eigen::Matrix<double, 3, 1> & A_r, const Rotation & rotationBToA,
     const Eigen::Matrix<double, 3, 1> & B_r)
   {
-    tf::Vector3 A_v = tf::quatRotate(rotationBToA, tf::Vector3(B_r.x(), B_r.y(), B_r.z()));
+    tf2::Vector3 A_v = tf2::quatRotate(rotationBToA, tf2::Vector3(B_r.x(), B_r.y(), B_r.z()));
     A_r.x() = A_v.x();
     A_r.y() = A_v.y();
     A_r.z() = A_v.z();
@@ -100,10 +102,10 @@ public:
 
 
 template<>
-class RotationConversion<tf::Matrix3x3, tf::Vector3, double>
+class RotationConversion<tf2::Matrix3x3, tf2::Vector3, double>
 {
-  typedef tf::Matrix3x3 Rotation;
-  typedef tf::Vector3 Vector;
+  typedef tf2::Matrix3x3 Rotation;
+  typedef tf2::Vector3 Vector;
 
 public:
   inline static void convertToOtherRotation(
@@ -111,12 +113,12 @@ public:
     const kindr::RotationQuaternion<double> & in)
   {
     kindr::RotationQuaternion<double> in2 = in;
-    out.setRotation(tf::Quaternion(in2.x(), in2.y(), in2.z(), in2.w()));
+    out.setRotation(tf2::Quaternion(in2.x(), in2.y(), in2.z(), in2.w()));
   }
 
   inline static void convertToKindr(kindr::RotationQuaternion<double> & out, Rotation & matrix)
   {
-    tf::Quaternion quat;
+    tf2::Quaternion quat;
     matrix.getRotation(quat);
     out = kindr::RotationQuaternion<double>(quat.w(), quat.x(), quat.y(), quat.z());
   }
@@ -125,7 +127,7 @@ public:
     Vector & out, Rotation & rot,
     const Eigen::Matrix<double, 3, 1> & in)
   {
-    out = tf::Vector3(in.x(), in.y(), in.z());
+    out = tf2::Vector3(in.x(), in.y(), in.z());
   }
 
   inline static void concatenate(Rotation & res, const Rotation & rot1, const Rotation & rot2)
@@ -148,8 +150,8 @@ public:
     Eigen::Matrix<double, 3, 1> & A_r, const Rotation & rotationBToA,
     const Eigen::Matrix<double, 3, 1> & B_r)
   {
-    tf::Vector3 B_v(B_r.x(), B_r.y(), B_r.z());
-    tf::Vector3 A_v = rotationBToA * B_v;
+    tf2::Vector3 B_v(B_r.x(), B_r.y(), B_r.z());
+    tf2::Vector3 A_v = rotationBToA * B_v;
     A_r.x() = A_v.x();
     A_r.y() = A_v.y();
     A_r.z() = A_v.z();
@@ -161,20 +163,20 @@ public:
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 TEST(TfConventionTest, Concatenation) {
-  kindr::ConventionTest<tf::Quaternion, tf::Vector3, double>::testConcatenation();
-  kindr::ConventionTest<tf::Matrix3x3, tf::Vector3, double>::testConcatenation();
+  kindr::ConventionTest<tf2::Quaternion, tf2::Vector3, double>::testConcatenation();
+  kindr::ConventionTest<tf2::Matrix3x3, tf2::Vector3, double>::testConcatenation();
 }
 
 TEST(TfConventionTest, Rotation) {
-  kindr::ConventionTest<tf::Quaternion, tf::Vector3, double>::testRotationMatrix();
-  kindr::ConventionTest<tf::Matrix3x3, tf::Vector3, double>::testRotationMatrix();
+  kindr::ConventionTest<tf2::Quaternion, tf2::Vector3, double>::testRotationMatrix();
+  kindr::ConventionTest<tf2::Matrix3x3, tf2::Vector3, double>::testRotationMatrix();
 }
 
 // TEST(TfConventionTest, BoxPlus) {
-//  kindr::ConventionTest<tf::Quaternion, tf::Vector3, double>::testBoxPlus();
+//  kindr::ConventionTest<tf2::Quaternion, tf2::Vector3, double>::testBoxPlus();
 // }
 
 TEST(TfConventionTest, GeometricalInterpretation) {
-  kindr::ConventionTest<tf::Quaternion, tf::Vector3, double>::testGeometricalInterpretation();
-  kindr::ConventionTest<tf::Matrix3x3, tf::Vector3, double>::testGeometricalInterpretation();
+  kindr::ConventionTest<tf2::Quaternion, tf2::Vector3, double>::testGeometricalInterpretation();
+  kindr::ConventionTest<tf2::Matrix3x3, tf2::Vector3, double>::testGeometricalInterpretation();
 }

--- a/kindr_ros/test/TfConventionTest.cpp
+++ b/kindr_ros/test/TfConventionTest.cpp
@@ -64,9 +64,7 @@ public:
     out = kindr::RotationQuaternion<double>(in.w(), in.x(), in.y(), in.z());
   }
 
-  inline static void convertToVelocityVector(
-    Vector & out, Rotation & rot,
-    const Eigen::Matrix<double, 3, 1> & in)
+  inline static void convertToVelocityVector(Vector & out, const Eigen::Matrix<double, 3, 1> & in)
   {
     out = tf2::Vector3(in.x(), in.y(), in.z());
   }
@@ -124,7 +122,7 @@ public:
   }
 
   inline static void convertToOtherVelocityVector(
-    Vector & out, Rotation & rot,
+    Vector & out,
     const Eigen::Matrix<double, 3, 1> & in)
   {
     out = tf2::Vector3(in.x(), in.y(), in.z());

--- a/kindr_ros/test/TfConventionTest.cpp
+++ b/kindr_ros/test/TfConventionTest.cpp
@@ -1,4 +1,31 @@
 /*
+ * Copyright (c) 2016, Peter Fankhauser, Christian Gehring, Hannes Sommer, Paul Furgale, Remo Diethelm
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Autonomous Systems Lab, ETH Zurich nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL Peter Fankhauser, Christian Gehring, Hannes Sommer, Paul Furgale,
+ * Remo Diethelm BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
+ * OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+*/
+/*
  * tf_kindr_test.cpp
  *
  *  Created on: Jun 17, 2016
@@ -12,87 +39,117 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-namespace kindr {
+namespace kindr
+{
 
 template<>
-class RotationConversion<tf::Quaternion, tf::Vector3, double> {
+class RotationConversion<tf::Quaternion, tf::Vector3, double>
+{
   typedef tf::Quaternion Rotation;
   typedef tf::Vector3 Vector;
- public:
 
-  inline static void convertToOtherRotation(Rotation& out, const kindr::RotationQuaternion<double>& in) {
+public:
+  inline static void convertToOtherRotation(
+    Rotation & out,
+    const kindr::RotationQuaternion<double> & in)
+  {
     kindr::RotationQuaternion<double> in2 = in;
     out = tf::Quaternion(in2.x(), in2.y(), in2.z(), in2.w());
   }
 
-  inline static void convertToKindr(kindr::RotationQuaternion<double>& out, Rotation& in) {
+  inline static void convertToKindr(kindr::RotationQuaternion<double> & out, Rotation & in)
+  {
     out = kindr::RotationQuaternion<double>(in.w(), in.x(), in.y(), in.z());
   }
 
-  inline static void convertToVelocityVector(Vector& out, Rotation& rot, const Eigen::Matrix<double,3,1>& in) {
+  inline static void convertToVelocityVector(
+    Vector & out, Rotation & rot,
+    const Eigen::Matrix<double, 3, 1> & in)
+  {
     out = tf::Vector3(in.x(), in.y(), in.z());
   }
 
-  inline static void concatenate(Rotation& res, const Rotation& rot1, const Rotation& rot2) {
-    res = rot2*rot1;
+  inline static void concatenate(Rotation & res, const Rotation & rot1, const Rotation & rot2)
+  {
+    res = rot2 * rot1;
   }
 
-  inline static void getRotationMatrixFromRotation(Eigen::Matrix3d& rotationMatrix, const Rotation& quaternion) {
+  inline static void getRotationMatrixFromRotation(
+    Eigen::Matrix3d & rotationMatrix,
+    const Rotation & quaternion)
+  {
     tf::Matrix3x3 tfRotationmatrix;
     tfRotationmatrix.setRotation(quaternion);
-    for (int i=0; i<3; i++) {
+    for (int i = 0; i < 3; i++) {
       rotationMatrix(i, 0) = tfRotationmatrix.getRow(i).x();
       rotationMatrix(i, 1) = tfRotationmatrix.getRow(i).y();
       rotationMatrix(i, 2) = tfRotationmatrix.getRow(i).z();
     }
   }
 
-  inline static void rotateVector(Eigen::Matrix<double,3,1>& A_r, const Rotation& rotationBToA, const Eigen::Matrix<double,3,1>& B_r) {
+  inline static void rotateVector(
+    Eigen::Matrix<double, 3, 1> & A_r, const Rotation & rotationBToA,
+    const Eigen::Matrix<double, 3, 1> & B_r)
+  {
     tf::Vector3 A_v = tf::quatRotate(rotationBToA, tf::Vector3(B_r.x(), B_r.y(), B_r.z()));
     A_r.x() = A_v.x();
     A_r.y() = A_v.y();
     A_r.z() = A_v.z();
   }
-
 };
 
 
 template<>
-class RotationConversion<tf::Matrix3x3, tf::Vector3, double> {
+class RotationConversion<tf::Matrix3x3, tf::Vector3, double>
+{
   typedef tf::Matrix3x3 Rotation;
   typedef tf::Vector3 Vector;
- public:
 
-  inline static void convertToOtherRotation(Rotation& out, const kindr::RotationQuaternion<double>& in) {
+public:
+  inline static void convertToOtherRotation(
+    Rotation & out,
+    const kindr::RotationQuaternion<double> & in)
+  {
     kindr::RotationQuaternion<double> in2 = in;
     out.setRotation(tf::Quaternion(in2.x(), in2.y(), in2.z(), in2.w()));
   }
 
-  inline static void convertToKindr(kindr::RotationQuaternion<double>& out, Rotation& matrix) {
+  inline static void convertToKindr(kindr::RotationQuaternion<double> & out, Rotation & matrix)
+  {
     tf::Quaternion quat;
     matrix.getRotation(quat);
     out = kindr::RotationQuaternion<double>(quat.w(), quat.x(), quat.y(), quat.z());
   }
 
-  inline static void convertToOtherVelocityVector(Vector& out, Rotation& rot, const Eigen::Matrix<double,3,1>& in) {
+  inline static void convertToOtherVelocityVector(
+    Vector & out, Rotation & rot,
+    const Eigen::Matrix<double, 3, 1> & in)
+  {
     out = tf::Vector3(in.x(), in.y(), in.z());
   }
 
-  inline static void concatenate(Rotation& res, const Rotation& rot1, const Rotation& rot2) {
-    res = rot2*rot1;
+  inline static void concatenate(Rotation & res, const Rotation & rot1, const Rotation & rot2)
+  {
+    res = rot2 * rot1;
   }
 
-  inline static void getRotationMatrixFromRotation(Eigen::Matrix3d& rotationMatrix, const Rotation& matrix) {
-    for (int i=0; i<3; i++) {
+  inline static void getRotationMatrixFromRotation(
+    Eigen::Matrix3d & rotationMatrix,
+    const Rotation & matrix)
+  {
+    for (int i = 0; i < 3; i++) {
       rotationMatrix(i, 0) = matrix.getRow(i).x();
       rotationMatrix(i, 1) = matrix.getRow(i).y();
       rotationMatrix(i, 2) = matrix.getRow(i).z();
     }
   }
 
-  inline static void rotateVector(Eigen::Matrix<double,3,1>& A_r, const Rotation& rotationBToA, const Eigen::Matrix<double,3,1>& B_r) {
+  inline static void rotateVector(
+    Eigen::Matrix<double, 3, 1> & A_r, const Rotation & rotationBToA,
+    const Eigen::Matrix<double, 3, 1> & B_r)
+  {
     tf::Vector3 B_v(B_r.x(), B_r.y(), B_r.z());
-    tf::Vector3 A_v = rotationBToA*B_v;
+    tf::Vector3 A_v = rotationBToA * B_v;
     A_r.x() = A_v.x();
     A_r.y() = A_v.y();
     A_r.z() = A_v.z();
@@ -100,7 +157,7 @@ class RotationConversion<tf::Matrix3x3, tf::Vector3, double> {
 };
 
 
-} // namespace kindr
+}  // namespace kindr
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 TEST(TfConventionTest, Concatenation) {
@@ -113,9 +170,9 @@ TEST(TfConventionTest, Rotation) {
   kindr::ConventionTest<tf::Matrix3x3, tf::Vector3, double>::testRotationMatrix();
 }
 
-//TEST(TfConventionTest, BoxPlus) {
+// TEST(TfConventionTest, BoxPlus) {
 //  kindr::ConventionTest<tf::Quaternion, tf::Vector3, double>::testBoxPlus();
-//}
+// }
 
 TEST(TfConventionTest, GeometricalInterpretation) {
   kindr::ConventionTest<tf::Quaternion, tf::Vector3, double>::testGeometricalInterpretation();

--- a/kindr_ros/test/test_main.cpp
+++ b/kindr_ros/test/test_main.cpp
@@ -29,7 +29,8 @@
 
 
 /// Run all the tests that were declared with TEST()
-int main(int argc, char **argv){
+int main(int argc, char ** argv)
+{
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
Summary of non-ROS2 specific changes. These could potentially be cherry picked into the ROS1 branch to avoid future merge conflicts:

- Using tf2 instead of tf (f022c41ba831a5d8db15041fe09f85f96dbf8440)
- Linted all files in kindr_msgs and kindr_ros with cppcheck, cpplint, lint_cmake, xmllint, and uncrustify (af5667c08e3b9fb484385dec702bd95356eacbb2, 51b18eccbed6ce7f77df2acc4248a459d2943a43)
- Removed what looks to be unnecessary variables that triggered unused-but-set-variable warnings (250f0e03d57ca640850ba54c0171875e164605ca)

ROS2 specific changes:

- Updated the package.xml format
- Replaced catkin with ament_cmake
- Changed geometry_msgs include paths, and namespace to the new ROS2 convention.

All 18 gtests run and pass for me. I've targeted ROS2 Galactic, but I see not reason why it shouldn't work with ROS2 Foxy.

The rviz plugins haven't been ported yet.
